### PR TITLE
Add charts for external secrets configuration

### DIFF
--- a/charts/external-secrets-config/.helmignore
+++ b/charts/external-secrets-config/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/external-secrets-config/Chart.yaml
+++ b/charts/external-secrets-config/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: external-secrets-config
+description: A Helm chart for External Secrets configurations
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.0"

--- a/charts/external-secrets-config/templates/_helpers.tpl
+++ b/charts/external-secrets-config/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "external-secrets-config.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "external-secrets-config.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "external-secrets-config.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "external-secrets-config.labels" -}}
+helm.sh/chart: {{ include "external-secrets-config.chart" . }}
+{{ include "external-secrets-config.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "external-secrets-config.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "external-secrets-config.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "external-secrets-config.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "external-secrets-config.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/external-secrets-config/templates/clustersecretstore.yaml
+++ b/charts/external-secrets-config/templates/clustersecretstore.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.clusterSecretStore.enabled -}}
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: {{ .Values.clusterSecretStore.name }}
+spec:
+  provider:
+    {{- range $key, $value := .Values.clusterSecretStore.provider }}
+    {{ $key }}: 
+      {{- range $subkey, $subvalue := $value }}
+      {{ $subkey }}: {{ $subvalue }}
+      {{- end }}
+    {{- end }}
+  {{- if .Values.clusterSecretStore.secretStoreRef }}
+  secretStoreRef:
+    name: {{ .Values.clusterSecretStore.secretStoreRef.name }}
+  {{- end }}
+  {{- end }}

--- a/charts/external-secrets-config/templates/externalsecret.yaml
+++ b/charts/external-secrets-config/templates/externalsecret.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.externalsecrets }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.externalsecrets.name }}
+  namespace: {{ .Values.externalsecrets.namespace }}
+spec:
+  data:
+  {{- range .Values.externalsecrets.data }}
+    - key: {{ .key }}
+      name: {{ .name }}
+      property: {{ .property }}
+  {{- end }}
+  secretStoreRef:
+    name: {{ .Values.externalsecrets.secretStoreRef.name }}
+    namespace: {{ .Values.externalsecrets.secretStoreRef.namespace }}
+  target:
+    name: {{ .Values.externalsecrets.target.name }}
+    namespace: {{ .Values.externalsecrets.target.namespace }}
+{{- end }}

--- a/charts/external-secrets-config/templates/secretstore.yaml
+++ b/charts/external-secrets-config/templates/secretstore.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.secretStore.enabled -}}
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: {{ .Values.secretStore.name }}
+spec:
+  provider:
+    {{ .Values.secretStore.provider }}:
+      {{- if .Values.secretStore.provider.vault }}
+      server: {{ .Values.secretStore.provider.vault.server }}
+      path: {{ .Values.secretStore.provider.vault.path }}
+      version: {{ .Values.secretStore.provider.vault.version }}
+      auth:
+        {{- if .Values.secretStore.provider.vault.auth.tokenSecretRef }}
+        tokenSecretRef:
+          name: {{ .Values.secretStore.provider.vault.auth.tokenSecretRef.name }}
+          key: {{ .Values.secretStore.provider.vault.auth.tokenSecretRef.key }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/charts/external-secrets-config/values.yaml
+++ b/charts/external-secrets-config/values.yaml
@@ -1,0 +1,40 @@
+clusterSecretStore:
+  enabled: true
+  name: my-cluster-secret-store
+  namespace: my-namespace
+  provider:
+    vault:
+      server: "http://my.vault.server:8200"
+      path: "secret"
+      version: "v2"
+      auth:
+        tokenSecretRef:
+          name: "vault-token"
+  refreshInterval: 1h
+
+secretStore:
+  enabled: true
+  name: vault-backend
+  provider:
+    vault:
+      server: "http://my.vault.server:8200"
+      path: "secret"
+      version: "v2"
+      auth:
+        tokenSecretRef:
+          name: "vault-token"
+          key: "token"
+
+externalsecrets:
+  name: my-external-secrets
+  namespace: my-namespace
+  secretStoreRef:
+    name: my-secret-store
+    namespace: my-namespace
+  target:
+    name: my-secret
+    namespace: my-namespace
+  data:
+    - key: my-key
+      name: my-secret
+      property: my-property


### PR DESCRIPTION
This pull request adds Helm charts for configuring external secrets. It includes the necessary YAML files for creating a cluster secret store, a secret store, and an external secret. The charts are designed to work with a Vault provider and allow for easy management of secrets in Kubernetes.